### PR TITLE
added `WHISK_FORK_EPOCH` env variable to beaconlight container

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -101,3 +101,5 @@
       beaconlight_chain_displayname: "whisk-testnet-0"
       beaconlight_frontend_subtitle: "Whisk Testnet"
       beaconlight_beaconapi_endpoint: "http://beacon:5052"
+      beaconlight_container_env:
+        WHISK_FORK_EPOCH: 0


### PR DESCRIPTION
custom setting to activate whisk special handling of proposer duties in light-beaconchain-explorer.

I'm not sure about the fork epoch?  
I guess the network starts with SSLE already?