### PR TITLE
increase `slots-per-restore-point`on bootnode

### DIFF
--- a/ansible/inventories/whisk-testnet-0/group_vars/bootnode.yaml
+++ b/ansible/inventories/whisk-testnet-0/group_vars/bootnode.yaml
@@ -29,7 +29,7 @@ lighthouse_container_volumes:
 lighthouse_container_command_extra_args:
   - --testnet-dir=/network-config
   - --debug-level=debug
-  - --slots-per-restore-point=32
+  - --slots-per-restore-point=256
 
 # role: ethpandaops.general.geth
 geth_container_name: execution


### PR DESCRIPTION
The bootnode is running out of disk space, there is currently only 3G left on the 80G disk.

Disk space is mainly consumed by the lighthouse node due to the `slots-per-restore-point` being set to `32`:
```
63G	/data/lighthouse
```

This PR changes the `slots-per-restore-point` to `256`. I've done a lot of improvements on the explorer side, so the low sprp setting isn't really needed anymore as the explorer fetches old duties less frequently.

An increase of `slots-per-restore-point` by x8 should lower the disk space need by x8, which gives us enough space for the next months :)

bootnode needs a resync to apply the change.