### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install asdf
-      uses: asdf-vm/actions/setup@v2
+      uses: asdf-vm/actions/setup@7dd2d2ea8a8f52028ca0fdfba65767b8f2db8298 # v2
 
     - name: Install asdf tools
       shell: bash

--- a/.github/workflows/lint-ansible.yaml
+++ b/.github/workflows/lint-ansible.yaml
@@ -19,7 +19,7 @@ jobs:
   job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: ./.github/actions/setup
       - name: Install ansible role/collection dependencies
         working-directory: ./ansible

--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -19,7 +19,7 @@ jobs:
   job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: ./.github/actions/setup
       - name: Lint
         run: >

--- a/.github/workflows/lint-terraform.yaml
+++ b/.github/workflows/lint-terraform.yaml
@@ -19,7 +19,7 @@ jobs:
   job:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - uses: ./.github/actions/setup
       - name: Lint
         working-directory: ./terraform


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.